### PR TITLE
Add `toDataFrame()` to `NotebookHttpResponse`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlinx-serialization = "1.6.2"
 jvm-toolchain = "11"
 kotlin-jupyter = "0.12.0-142"
 kotlinpoet = "1.18.1"
+dataframe = "0.13.1"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -15,7 +16,7 @@ kotlin-jupyter-api = { id = "org.jetbrains.kotlin.jupyter.api", version.ref = "k
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
-
+dataframe = { module = "org.jetbrains.kotlinx:dataframe", version.ref = "dataframe" }
 ktor-client-core = { module = "io.ktor:ktor-client-core-jvm", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio-jvm", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation-jvm", version.ref = "ktor" }

--- a/ktor-client-core/build.gradle.kts
+++ b/ktor-client-core/build.gradle.kts
@@ -12,8 +12,10 @@ kotlinJupyter {
 
 dependencies {
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.dataframe)
     api(libs.ktor.client.core)
     runtimeOnly(libs.ktor.client.cio)
+    compileOnly(libs.dataframe)
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.serialization.kotlinx.json)
 }

--- a/ktor-client-core/src/main/kotlin/ext.kt
+++ b/ktor-client-core/src/main/kotlin/ext.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.kotlinx.jupyter.ktor.client.core
+
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.dataframe.io.readJsonStr
+
+/**
+ * If the server returned a JSON response, it can be converted directly to a Kotlin DataFrame using this method.
+ *
+ * @throws IllegalStateException if the server didn't respond with a `Content-Type: application/json` header.
+ * @throws ClassNotFoundException if Kotlin DataFrames are not on the classpath. It can be added using `%use dataframe`.
+ */
+public fun NotebookHttpResponse.toDataFrame(): DataFrame<*> {
+    return runBlocking {
+        if (ktorResponse.contentType() != ContentType.Application.Json) {
+            throw IllegalStateException("HTTP request did not return JSON, but ${ktorResponse.contentType()}")
+        }
+        val json = ktorResponse.bodyAsText()
+        DataFrame.readJsonStr(json)
+    }
+}

--- a/ktor-client-core/src/test/kotlin/KtorClientCoreIntegrationTest.kt
+++ b/ktor-client-core/src/test/kotlin/KtorClientCoreIntegrationTest.kt
@@ -2,6 +2,8 @@ package org.jetbrains.kotlinx.jupyter.ktor.client.core
 
 import kotlinx.serialization.json.JsonElement
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlinx.dataframe.DataFrame
+import org.jetbrains.kotlinx.jupyter.repl.result.EvalResultEx
 import org.jetbrains.kotlinx.jupyter.testkit.JupyterReplTestCase
 import org.jetbrains.kotlinx.jupyter.testkit.ReplProvider
 import org.junit.jupiter.api.Test
@@ -92,5 +94,73 @@ class KtorClientCoreIntegrationTest : JupyterReplTestCase(
         val response5 = execRaw("""client.get("https://example.org").readBytes()""")
         assertIs<ByteArray>(response5)
         assertEquals(json, response5.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `create dataframe from response`() {
+        val json = """[{"a": 1}, {"a": 2}, {"a": 3}]"""
+        execRaw(
+            """
+                %use serialization
+                @file:DependsOn("io.ktor:ktor-client-mock-jvm:2.3.7")
+                
+                import io.ktor.client.engine.mock.*
+                import io.ktor.client.plugins.contentnegotiation.*
+                import io.ktor.http.*
+                import io.ktor.serialization.kotlinx.json.*
+                
+                @Serializable
+                data class A(val b: String, val a: A?)
+                
+                val client = NotebookHttpClient(MockEngine) {
+                    install(ContentNegotiation) {
+                        json()
+                    }
+                    engine {
+                        addHandler {
+                            respond(
+                                content = ""${'"'}$json""${'"'},
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            )
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+        val response = execRaw("""client.get("https://example.org").toDataFrame()""")
+        assertIs<DataFrame<*>>(response)
+    }
+
+    @Test
+    fun `cannot create dataframe from response that doesn't return json`() {
+        execRaw(
+            """
+                %use serialization
+                @file:DependsOn("io.ktor:ktor-client-mock-jvm:2.3.7")
+                
+                import io.ktor.client.engine.mock.*
+                import io.ktor.client.plugins.contentnegotiation.*
+                import io.ktor.http.*
+                import io.ktor.serialization.kotlinx.json.*
+                
+                val client = NotebookHttpClient(MockEngine) {
+                    install(ContentNegotiation) {
+                        json()
+                    }
+                    engine {
+                        addHandler {
+                            respond(
+                                content = ""${'"'}error""${'"'},
+                                status = HttpStatusCode.InternalServerError,
+                            )
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+        val res = execEx("""client.get("https://example.org").toDataFrame()""")
+        assertIs<EvalResultEx.Error>(res)
+        assertIs<IllegalStateException>(res.error.cause)
     }
 }


### PR DESCRIPTION
When exploring a REST API and you want to visualize the response, the easiest is to convert the response to a DataFrame which can be fed to Kandy.

This requires manual conversion which is annoying to write and requires some knowledge about how DataFrames are loading data. To make this easier, this PR adds a new extension method `NotebookHttpResponse.toDataFrame()`.

```
val df = oaiClient.get("path/to/resource").toDataFrame()
```

Rather than:

```
val response = oaiClient.get("path/to/resource")
val json = response.bodyAsText()
val df = DataFrame.readJsonStr(json)
```